### PR TITLE
chore: change android default navigation animation to `fade`

### DIFF
--- a/src/navigation/RootStack.tsx
+++ b/src/navigation/RootStack.tsx
@@ -1,5 +1,6 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 
+import { isAndroid } from 'src/constants/platform'
 import { BottomStack } from 'src/navigation/BottomStack'
 import { Routes } from 'src/navigation/routes'
 import type { RootStackParamList } from 'src/navigation/types'
@@ -14,7 +15,7 @@ export const RootStack = () => {
   const isLoggedIn = Boolean(accessToken)
 
   return (
-    <Root.Navigator>
+    <Root.Navigator screenOptions={{ animation: isAndroid ? 'fade' : 'default' }}>
       {isLoggedIn ? (
         <>
           <Root.Screen


### PR DESCRIPTION
I discussed with Lubos Modrak from Android what default screen navigation transition they use because the React Navigation default scale transition seems always off to me. Actually they mentioned that they usually don't have much time to handpick the transitions but use `fade` as default. I wonder if we should change it as well. To me, the fade definitely feels more elegant and less glitchy in comparison when the scale is applied.

I also went through the android material [docs](https://m2.material.io/design/navigation/navigation-transitions.html) and found that the React Navigation implementation is something like [z-axis transition](https://m2.material.io/design/motion/the-motion-system.html#shared-axis). But even when using the native RN header, it transitions differently anyway

comparison on the Ascension app:
**Default**:

https://user-images.githubusercontent.com/32416348/213993050-ee9e554f-6a88-4d45-a283-581e93c77786.mp4

**Fade**:

https://user-images.githubusercontent.com/32416348/213992984-a8b56167-554c-49ee-bd25-8216b09c0a9a.mp4
