### PR TITLE
fix: useOnForeground duplicate listener

### DIFF
--- a/src/hooks/useOnForeground.tsx
+++ b/src/hooks/useOnForeground.tsx
@@ -1,29 +1,24 @@
-import { useState, useEffect } from 'react'
-import { type AppStateStatus } from 'react-native'
-import { AppState } from 'react-native'
+import { useEffect, useRef } from 'react'
+import { AppState, type AppStateStatus } from 'react-native'
 
 import { useLatestValue } from '~/hooks/useLatest'
 
 export function useOnForeground(onForeground: () => void, includeFirstLoad = false) {
-  const [appState, setAppState] = useState(AppState.currentState)
-
-  const latestAppState = useLatestValue(appState)
+  const appState = useRef(AppState.currentState)
   const latestOnForeground = useLatestValue(onForeground)
 
   useEffect(() => {
     const handleAppStateChange = (nextAppState: AppStateStatus) => {
-      if (latestAppState.current.match(/inactive|background/u) && nextAppState === 'active') {
+      if (appState.current.match(/inactive|background/u) && nextAppState === 'active') {
         latestOnForeground.current()
       }
-      setAppState(nextAppState)
+      appState.current = nextAppState
     }
 
     if (includeFirstLoad) latestOnForeground.current()
 
     const subscription = AppState.addEventListener('change', handleAppStateChange)
-    AppState.addEventListener('change', handleAppStateChange)
 
     return () => subscription.remove()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [includeFirstLoad, latestOnForeground])
 }


### PR DESCRIPTION
## Summary

- Fixed a bug where `AppState.addEventListener` was called twice, causing the foreground callback to fire twice on every app resume
- Replaced `useState` with `useRef` for app state tracking since we only need it for comparison, not rendering